### PR TITLE
[aml/meson6g18]- add support for aml video capture device

### DIFF
--- a/arch/arm/boot/dts/amlogic/meson6_g18.dtd
+++ b/arch/arm/boot/dts/amlogic/meson6_g18.dtd
@@ -1398,5 +1398,19 @@ void root_func(){
 		fe0_dev = <0>;
 
 	};
+
+/// ***************************************************************************************
+/// - DISP&MM-A/V Amvideocap
+//$$ MODULE = "DISP&MM-Amvideocap"
+//$$ DEVICE="amvideocap"
+//$$ L2 PROP_STR = "status"
+//$$ L3 PROP_U32 4 ="reg"
+ amvideocap{
+ compatible = "amlogic,amvideocap";
+ dev_name = "amvideocap.0";
+ status = "okay";
+ reserve-memory = <0x00a00000>; // 1920 * 1088 * 4 = 8,355,840
+ reserve-iomap = "true";
+ };
 }; /* end of / */
 


### PR DESCRIPTION
- this is needed for getting /dev/amvideocap0 which gives userspace access to the current video frame (f.e. used for boblight)