### PR TITLE
[WeTek_Play] - enable cputemp sensor

### DIFF
--- a/arch/arm/mach-meson6/cpu.c
+++ b/arch/arm/mach-meson6/cpu.c
@@ -59,6 +59,14 @@ EXPORT_SYMBOL(get_meson_cpu_version);
 int mali_revb_flag = -1;
 //int mali_version(void)
 
+int (*get_cpu_temperature_celius)(void) = NULL;
+EXPORT_SYMBOL_GPL(get_cpu_temperature_celius);
+
+int get_cpu_temperature(void)
+{
+    return get_cpu_temperature_celius ? get_cpu_temperature_celius() : -1;
+}
+
 EXPORT_SYMBOL_GPL(mali_revb_flag);
 static int __init maliversion(char *str)
 {


### PR DESCRIPTION
As the topic says - this enables the sysfs access to the sar adc which has a temperature sensor connected as it seems. It can be accessed via:

/sys/class/saradc/temperature 

and should return the temperature in degree celsius. Unfortunatly the conversion from ADC Value to celsius doesn't fit the used hardware/resistor network and needs to be fixed here:

https://github.com/codesnake/linux-amlogic/blob/master/drivers/amlogic/input/saradc/saradc.c#L356

by someone who has access to the schematics...