### PR TITLE
Properly set max_blk_count and max_blk_size for the host mmc

### DIFF
--- a/drivers/amlogic/mmc/aml_sdio.c
+++ b/drivers/amlogic/mmc/aml_sdio.c
@@ -1322,10 +1322,10 @@ static int aml_sdio_probe(struct platform_device *pdev)
         mmc->alldev_claim = &aml_sdio_claim;
         mmc->ios.clock = 400000;
         mmc->ios.bus_width = MMC_BUS_WIDTH_1;
-        mmc->max_blk_count = 4095;
-        mmc->max_blk_size = 4095;
+        mmc->max_blk_count = 256;
         mmc->max_req_size = pdata->max_req_size;
         mmc->max_seg_size = mmc->max_req_size;
+        mmc->max_blk_size = mmc->max_req_size / mmc->max_blk_count;
         mmc->max_segs = 1024;
         mmc->ocr_avail = pdata->ocr_avail;
         mmc->ocr = pdata->ocr_avail;


### PR DESCRIPTION
`mmc_host.max_blk_count` and `mmc_hostmax_blk_size` and not properly set by the Amlogic SDIO driver.

This causes newer drivers, such as brcmfmac, to trigger the assertion at https://github.com/codesnake/linux-amlogic/blob/master/drivers/amlogic/mmc/aml_sdio.c#L317

Using this assertion, and the `max_req_size` provided by the DTD, we can calculate the proper values.

I believe this is an actual bug in the kernel.