### PR TITLE
Disable deinterlacer for progressive sources by default

### DIFF
--- a/drivers/amlogic/deinterlace/deinterlace.c
+++ b/drivers/amlogic/deinterlace/deinterlace.c
@@ -192,7 +192,7 @@ static int receiver_is_amvideo = 1;
 
 static unsigned char new_keep_last_frame_enable = 0;
 static int bypass_state = 1;
-static int bypass_prog = 0;
+static int bypass_prog = 1;
 static int bypass_hd_prog = 0;
 #if (MESON_CPU_TYPE>=MESON_CPU_TYPE_MESON8)
 static int bypass_interlace_output = 0;


### PR DESCRIPTION
Disabling deinterlacer for progressive sources by default fixes stuttering of VC-1 videos in MKV container. The issue seems to be kernel-related as it is present both in Android and Linux.

A sample somewhere from the net: https://www.dropbox.com/s/ji0d8q4h322pd8p/Jurassic%20Park%20(1993).REMUX.bluray%20(1)-001.mkv

This change seems not to impact interlaced sources.