### PR TITLE
allows to send device control messages

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
+++ b/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
@@ -1564,6 +1564,16 @@ void cec_routing_information(cec_rx_message_t* pcec_message)
 	    cec_global_info.cec_node_info[cec_global_info.my_node_index].menu_status = DEVICE_MENU_INACTIVE;
 	}
 }
+
+void cec_usrcmd_device_menu_control(unsigned char log_addr, unsigned char button)
+{
+    MSG_P1(cec_global_info.my_node_index, log_addr, CEC_OC_USER_CONTROL_PRESSED, button);
+    cec_ll_tx(gbl_msg, 3);
+
+    MSG_P0(cec_global_info.my_node_index, log_addr, CEC_OC_USER_CONTROL_RELEASED);
+    cec_ll_tx(gbl_msg, 2);
+}
+
 /***************************** cec middle level code end *****************************/
 
 
@@ -1876,6 +1886,9 @@ void cec_usrcmd_set_dispatch(const char * buf, size_t count)
         break;
     case PING_TV:    //0x1a LA : For TV CEC detected.
         detect_tv_support_cec(param[1]);
+        break;
+    case DEVICE_MENU_CONTROL:    //0x1b
+        cec_usrcmd_device_menu_control(param[1], param[2]);
         break;
     default:
         break;

--- a/include/linux/amlogic/hdmi_tx/hdmi_tx_cec.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_tx_cec.h
@@ -477,6 +477,7 @@ typedef enum {
     SET_TEXT_VIEW_ON,
     POLLING_ONLINE_DEV, //0x19
     PING_TV,
+    DEVICE_MENU_CONTROL, //0x1b
     USR_CMD_MAX,
 } usr_cmd_type_e;
 
@@ -545,6 +546,7 @@ void cec_usrcmd_set_deactive_source(unsigned char log_addr);
 void cec_usrcmd_clear_node_dev_real_info_mask(unsigned char log_addr, cec_info_mask mask);
 void cec_usrcmd_set_report_physical_address(void);
 void cec_usrcmd_text_view_on(unsigned char log_addr);
+void cec_usrcmd_device_menu_control(unsigned char log_addr, unsigned char button);
 void cec_polling_online_dev(int log_addr, int *bool);
 void cec_device_vendor_id(cec_rx_message_t* pcec_message);
 void cec_report_power_status(cec_rx_message_t* pcec_message);


### PR DESCRIPTION
This patch sends any remote control button to any logical device. I use it to power on my AVR because my TV doesn't do it:
echo "1b 15 40" >/sys/devices/virtual/amhdmitx/amhdmitx0/cec